### PR TITLE
Frontend 34 manage profiles page outline

### DIFF
--- a/app/components/manage-profiles.tsx
+++ b/app/components/manage-profiles.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Unstable_Grid2' ;
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import profileList from "./profileList"
+
+const BoxSx = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        minHeight: '90vh',
+        justifyContent: 'center',
+        alignItems: 'flex-start',
+        borderRadius: '5%',
+        backgroundColor: '#f6f6f6',
+        fontFamily: 'default',
+        margin: '2%'
+      }}
+    >
+      {/* everything above the profile list */}
+      <Grid container spacing={5} columnSpacing={{xs: 20, sm:80, md:5, lg:5}} columns={12} margin={8}>
+        <div class='headerContent'>
+          <Grid container spacing={6} columns={20} paddingBottom='10%'>
+            {/* Left side of header */}
+            <Grid item xs={14} paddingRight='15%'>
+              {/* Page Title */}
+              <Typography variant="h4" justifyContent='center' sx={{fontWeight: 'bold', paddingBottom:'10%'}}>
+                  Manage Profiles
+              </Typography>
+
+              {/* Search Bar */}
+              <Grid container spacing={2} columns={4}>
+                <Grid item xs={3}>
+                  <TextField fullWidth defaultValue="Search" InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} id="filled-basic" label="" variant="standard"/>
+                </Grid>
+                <Grid item xs={1}>
+                  <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">search</Button>
+                </Grid>
+              </Grid>
+            </Grid>
+            
+            {/* Right side of header */}
+            <Grid item xs={6}>
+              {/* Add new employee */}
+              <Grid container paddingBottom='16%'>
+                <Button fullWidth variant="outlined" sx={{ padding: '5%', borderRadius: '25px', textIndent: '10px', borderColor: "#57228F", backgroundColor: '#FFFFFF', color: "#000000", '&:hover': {borderColor:"#57228F"}, textTransform: 'none'}}>
+                    Add New Employee
+                </Button>
+              </Grid>
+
+              {/* Select filters */}
+              <Grid container spacing={2} columns={3}>
+                <Grid item xs={2}>
+                  <TextField fullWidth defaultValue="Select filters" InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} id="filled-basic" label="" variant="standard"/>
+                </Grid>
+                <Grid item xs={1}>
+                  <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">filter</Button>
+                </Grid>
+              </Grid>
+            </Grid>
+          </Grid>
+
+          {/* profile list component */}
+          <div class='profileList' sx={{ justifyContent:'center' }}>
+            <Grid item xs={12} sm={12} md={12} lg={12}>
+              {profileList({firstName: "N", lastName: "P", role: "volunteer", imageUrl: "image"})}
+            </Grid>
+          </div>
+
+        </div>
+        
+        
+      </Grid>
+  </Box>);
+}
+
+export default BoxSx;

--- a/app/components/manage-profiles.tsx
+++ b/app/components/manage-profiles.tsx
@@ -7,6 +7,8 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
+import Pagination from '@mui/material/Pagination';
+import Stack from '@mui/material/Stack';
 import profileList from "./profileList"
 import Image from "next/image";
 import Add from "app/images/9.png";
@@ -28,85 +30,82 @@ const BoxSx = () => {
       }}
     >
       {/* everything above the profile list */}
-      <Grid container spacing={3} columnSpacing={{xs: 20, sm:80, md:5, lg:5}} margin={10}>
-        <div className='headerContent'>
-          <Grid container spacing={3} columns={20} paddingBottom='10%'>
-            {/* Left side of header */}
-            <Grid item xs={12}>
-              {/* Page Title */}
-              <Typography variant="h4" justifyContent='center' sx={{fontWeight: 'bold', paddingBottom:'10%'}}>
-                  Manage Profiles
-              </Typography>
+      <Stack spacing={2}>
+        <Grid container spacing={3} columns={20} columnSpacing={{xs: 20, sm:80, md:5, lg:5}} margin={10} paddingTop='5%'>
+              {/* Left side of header */}
+              <Grid item xs={12} paddingBottom='5%'>
+                {/* Page Title */}
+                <Typography variant="h4" justifyContent='center' sx={{fontWeight: 'bold', paddingBottom:'10%'}}>
+                    Manage Profiles
+                </Typography>
 
-              {/* Search Bar */}
-              <Grid container spacing={3} columns={4}>
-                {/* Actual Search Bar */}
-                <Grid item xs={3}>
-                  <TextField fullWidth InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px', padding:'4px'}} id="filled-basic" label="" variant="standard"/>
+                {/* Search Bar */}
+                <Grid container spacing={3} columns={4}>
+                  {/* Actual Search Bar */}
+                  <Grid item xs={3}>
+                    <TextField fullWidth InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px', padding:'4px'}} id="filled-basic" label="" variant="standard"/>
+                  </Grid>
+                  {/* Search Button */}
+                  <Grid item xs={1}>
+                    <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">search</Button>
+                  </Grid>
                 </Grid>
-                {/* Search Button */}
-                <Grid item xs={1}>
-                  <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">search</Button>
+
+                {/* Applied filters */}
+                <Grid container spacing={2} item xs={12} paddingTop='2%' alignItems="center">
+                  <Grid item xs={2}>
+                    applied filters:
+                  </Grid>
+                  <Grid item xs={10}>
+                    <TextField defaultValue="All" InputProps={{ readOnly: true }} sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px' }} id="filled-basic" label="" variant="standard" />
+                  </Grid>
                 </Grid>
               </Grid>
 
-              {/* Applied filters */}
-              <Grid container spacing={2} item xs={12} paddingTop='2%' alignItems="center">
-                <Grid item xs={2}>
-                  applied filters:
+              {/* Dummy grid for vertical padding in header */}
+              <Grid item xs={1} />
+              
+              {/* Right side of header */}
+              <Grid item xs={6}>
+                {/* Add new employee */}
+                <Grid container paddingBottom='18%'>
+                  <Button fullWidth variant="outlined" sx={{ padding: '3%', borderRadius: '25px', borderColor: "#57228F", backgroundColor: '#FFFFFF', color: "#000000", '&:hover': {borderColor:"#57228F"}, textTransform: 'none', display: 'flex', alignItems: 'center' }}>
+                    <div style={{ flexGrow: 1 }}>Add New Employee</div>
+                    <Image src={Add} alt="Error" width={30} height={30} />
+                  </Button>
                 </Grid>
-                <Grid item xs={10}>
-                  <TextField defaultValue="All" InputProps={{ readOnly: true }} sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px' }} id="filled-basic" label="" variant="standard" />
+
+                {/* Select filters */}
+                <Grid container spacing={2} columns={3}>
+                  <Grid item xs={2}>
+                    <Select
+                      fullWidth
+                      value="" // Set the initial value to an empty string
+                      displayEmpty // Display the selected value even when it's empty
+                      sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px', height: '38px'}}
+                    >
+                      <MenuItem value="" disabled>
+                        Select filters
+                      </MenuItem>
+                      {/* Add more MenuItem components with filter options here */}
+                    </Select>
+                  </Grid>
+                  {/* Filter button */}
+                  <Grid item xs={1}>
+                    <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">filter</Button>
+                  </Grid>
                 </Grid>
-              </Grid>
-
-
+              {/* </Grid> */}
             </Grid>
+        </Grid>
 
-            <Grid item xs={1} />
-            
-            {/* Right side of header */}
-            <Grid item xs={6}>
-              {/* Add new employee */}
-              <Grid container paddingBottom='18%'>
-                <Button fullWidth variant="outlined" sx={{ padding: '3%', borderRadius: '25px', borderColor: "#57228F", backgroundColor: '#FFFFFF', color: "#000000", '&:hover': {borderColor:"#57228F"}, textTransform: 'none', display: 'flex', alignItems: 'center' }}>
-                  <div style={{ flexGrow: 1 }}>Add New Employee</div>
-                  <Image src={Add} alt="Error" width={30} height={30} />
-                </Button>
-              </Grid>
+        {/* Profile List */}
+        {profileList({firstName: "N", lastName: "P", role: "volunteer", imageUrl: "image"})}
 
-              {/* Select filters */}
-              <Grid container spacing={2} columns={3}>
-                <Grid item xs={2}>
-                  <Select
-                    fullWidth
-                    value="" // Set the initial value to an empty string
-                    displayEmpty // Display the selected value even when it's empty
-                    sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px', height: '38px'}}
-                  >
-                    <MenuItem value="" disabled>
-                      Select filters
-                    </MenuItem>
-                    {/* Add more MenuItem components with filter options here */}
-                  </Select>
-                </Grid>
-                {/* Filter button */}
-                <Grid item xs={1}>
-                  <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">filter</Button>
-                </Grid>
-              </Grid>
-            </Grid>
-          </Grid>
-
-          {/* profile list component */}
-          <div class='profileList' sx={{ justifyContent:'center' }}>
-            <Grid item xs={12} sm={12} md={12} lg={12}>
-              {profileList({firstName: "N", lastName: "P", role: "volunteer", imageUrl: "image"})}
-            </Grid>
-          </div>
-          
-        </div>
-      </Grid>
+        {/* Pagination */}
+        <Pagination count={10} variant="outlined" color="secondary" display='flex' justifyContent='flex-center'/> 
+        
+      </Stack>
   </Box>);
 }
 

--- a/app/components/manage-profiles.tsx
+++ b/app/components/manage-profiles.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+
+// Material-UI components
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Unstable_Grid2' ;
+import Grid from '@mui/material/Unstable_Grid2';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
@@ -9,9 +11,16 @@ import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import Pagination from '@mui/material/Pagination';
 import Stack from '@mui/material/Stack';
-import profileList from "./profileList"
+import SearchIcon from '@mui/icons-material/Search';
+import InputAdornment from '@mui/material/InputAdornment';
+import InputBase from '@mui/material/InputBase';
+
+// Custom components and images
+import profileList from "./profileList";
 import Image from "next/image";
 import Add from "app/images/9.png";
+import ClearIcon from '@mui/icons-material/Clear';
+
 
 const BoxSx = () => {
   return (
@@ -19,11 +28,9 @@ const BoxSx = () => {
       sx={{
         display: 'flex',
         minHeight: '90vh',
-        // justifyContent: 'center',
-        // alignItems: 'flex-start',
-        flexDirection: 'column', // Change flex direction to column
-        justifyContent: 'flex-start', // Align items at the start
-        alignItems: 'center', // Center items horizontally
+        flexDirection: 'column', 
+        justifyContent: 'flex-start',
+        alignItems: 'center', 
         borderRadius: '5%',
         backgroundColor: '#f6f6f6',
         fontFamily: 'default',
@@ -47,11 +54,26 @@ const BoxSx = () => {
                   <Grid container spacing={3} columns={4}>
                     {/* Actual Search Bar */}
                     <Grid item xs={3}>
-                      <TextField fullWidth InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px', padding:'4px'}} id="filled-basic" label="" variant="standard"/>
+                      <InputBase 
+                        fullWidth
+                        variant="outlined"
+                        endAdornment={
+                          <InputAdornment position="end">
+                            <SearchIcon />
+                          </InputAdornment>
+                        }
+                        sx={{
+                          backgroundColor: '#FFFFFF',
+                          borderRadius: '10px',
+                          padding: '3px',
+                          paddingLeft: '20px',
+                          paddingRight: '10px',
+                        }}
+                      />
                     </Grid>
                     {/* Search Button */}
                     <Grid item xs={1}>
-                      <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">search</Button>
+                      <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}} variant="contained">search</Button>
                     </Grid>
                   </Grid>
 
@@ -61,7 +83,23 @@ const BoxSx = () => {
                       applied filters:
                     </Grid>
                     <Grid item xs={10}>
-                      <TextField defaultValue="All" InputProps={{ readOnly: true }} sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px' }} id="filled-basic" label="" variant="standard" />
+                      <TextField
+                        defaultValue="    All"
+                        InputProps={{
+                          readOnly: true,
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              <ClearIcon />
+                            </InputAdornment>
+                          ),
+                        }}
+                        sx={{
+                          backgroundColor: '#FFFFFF',
+                          borderRadius: '10px',
+                          width: '70%',
+                        }}
+                        variant="standard"
+                      />
                     </Grid>
                   </Grid>
                 </Grid>

--- a/app/components/manage-profiles.tsx
+++ b/app/components/manage-profiles.tsx
@@ -29,82 +29,81 @@ const BoxSx = () => {
         marginRight: '5%'
       }}
     >
-      {/* everything above the profile list */}
-      <Stack spacing={2}>
-        <Grid container spacing={3} columns={20} columnSpacing={{xs: 20, sm:80, md:5, lg:5}} margin={10} paddingTop='5%'>
-              {/* Left side of header */}
-              <Grid item xs={12} paddingBottom='5%'>
-                {/* Page Title */}
-                <Typography variant="h4" justifyContent='center' sx={{fontWeight: 'bold', paddingBottom:'10%'}}>
-                    Manage Profiles
-                </Typography>
+      <Stack spacing={35}>
+        {/* Header content */}
+        <Stack spacing={2}>
+          <Grid container spacing={3} columns={20} columnSpacing={{xs: 20, sm:80, md:5, lg:5}} margin={10} paddingTop='5%'>
+                {/* Left side of header */}
+                <Grid item xs={14} paddingBottom='5%'>
+                  {/* Page Title */}
+                  <Typography variant="h4" sx={{fontWeight: 'bold', paddingBottom:'10%'}}>
+                      Manage Profiles
+                  </Typography>
 
-                {/* Search Bar */}
-                <Grid container spacing={3} columns={4}>
-                  {/* Actual Search Bar */}
-                  <Grid item xs={3}>
-                    <TextField fullWidth InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px', padding:'4px'}} id="filled-basic" label="" variant="standard"/>
+                  {/* Search Bar */}
+                  <Grid container spacing={3} columns={4}>
+                    {/* Actual Search Bar */}
+                    <Grid item xs={3}>
+                      <TextField fullWidth InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px', padding:'4px'}} id="filled-basic" label="" variant="standard"/>
+                    </Grid>
+                    {/* Search Button */}
+                    <Grid item xs={1}>
+                      <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">search</Button>
+                    </Grid>
                   </Grid>
-                  {/* Search Button */}
-                  <Grid item xs={1}>
-                    <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">search</Button>
+
+                  {/* Applied filters */}
+                  <Grid container spacing={2} item xs={12} paddingTop='2%' alignItems="center">
+                    <Grid item xs={2}>
+                      applied filters:
+                    </Grid>
+                    <Grid item xs={10}>
+                      <TextField defaultValue="All" InputProps={{ readOnly: true }} sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px' }} id="filled-basic" label="" variant="standard" />
+                    </Grid>
                   </Grid>
                 </Grid>
 
-                {/* Applied filters */}
-                <Grid container spacing={2} item xs={12} paddingTop='2%' alignItems="center">
-                  <Grid item xs={2}>
-                    applied filters:
+                {/* Right side of header */}
+                <Grid item xs={6}>
+                  {/* Add new employee */}
+                  <Grid container paddingBottom='23%'>
+                    <Button fullWidth variant="outlined" sx={{ padding: '3%', borderRadius: '25px', borderColor: "#57228F", backgroundColor: '#FFFFFF', color: "#000000", '&:hover': {borderColor:"#57228F"}, textTransform: 'none', display: 'flex', alignItems: 'center' }}>
+                      <div style={{ flexGrow: 1 }}>Add New Employee</div>
+                      <Image src={Add} alt="Error" width={30} height={30} />
+                    </Button>
                   </Grid>
-                  <Grid item xs={10}>
-                    <TextField defaultValue="All" InputProps={{ readOnly: true }} sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px' }} id="filled-basic" label="" variant="standard" />
+
+                  {/* Select filters */}
+                  <Grid container spacing={2} columns={3}>
+                    <Grid item xs={2}>
+                      <Select
+                        fullWidth
+                        value="" // Set the initial value to an empty string
+                        displayEmpty // Display the selected value even when it's empty
+                        sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px', height: '38px'}}
+                      >
+                        <MenuItem value="" disabled>
+                          Select filters
+                        </MenuItem>
+                        {/* Add more MenuItem components with filter options here */}
+                      </Select>
+                    </Grid>
+                    {/* Filter button */}
+                    <Grid item xs={1}>
+                      <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">filter</Button>
+                    </Grid>
                   </Grid>
-                </Grid>
               </Grid>
+          </Grid>
 
-              {/* Dummy grid for vertical padding in header */}
-              <Grid item xs={1} />
-              
-              {/* Right side of header */}
-              <Grid item xs={6}>
-                {/* Add new employee */}
-                <Grid container paddingBottom='18%'>
-                  <Button fullWidth variant="outlined" sx={{ padding: '3%', borderRadius: '25px', borderColor: "#57228F", backgroundColor: '#FFFFFF', color: "#000000", '&:hover': {borderColor:"#57228F"}, textTransform: 'none', display: 'flex', alignItems: 'center' }}>
-                    <div style={{ flexGrow: 1 }}>Add New Employee</div>
-                    <Image src={Add} alt="Error" width={30} height={30} />
-                  </Button>
-                </Grid>
-
-                {/* Select filters */}
-                <Grid container spacing={2} columns={3}>
-                  <Grid item xs={2}>
-                    <Select
-                      fullWidth
-                      value="" // Set the initial value to an empty string
-                      displayEmpty // Display the selected value even when it's empty
-                      sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px', height: '38px'}}
-                    >
-                      <MenuItem value="" disabled>
-                        Select filters
-                      </MenuItem>
-                      {/* Add more MenuItem components with filter options here */}
-                    </Select>
-                  </Grid>
-                  {/* Filter button */}
-                  <Grid item xs={1}>
-                    <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">filter</Button>
-                  </Grid>
-                </Grid>
-              {/* </Grid> */}
-            </Grid>
-        </Grid>
-
-        {/* Profile List */}
-        {profileList({firstName: "N", lastName: "P", role: "volunteer", imageUrl: "image"})}
+          {/* Profile List */}
+          {profileList({firstName: "N", lastName: "P", role: "volunteer", imageUrl: "image"})}
+        </Stack>
 
         {/* Pagination */}
-        <Pagination count={10} variant="outlined" color="secondary" display='flex' justifyContent='flex-center'/> 
-        
+        <div sx={{display:'flex', justifyContent:'center'}}>
+          <Pagination count={10} variant="outlined" color="secondary" /> 
+        </div>
       </Stack>
   </Box>);
 }

--- a/app/components/manage-profiles.tsx
+++ b/app/components/manage-profiles.tsx
@@ -3,7 +3,9 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Unstable_Grid2' ;
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
-import Autocomplete from '@mui/material/Autocomplete';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import profileList from "./profileList"
 
@@ -18,32 +20,48 @@ const BoxSx = () => {
         borderRadius: '5%',
         backgroundColor: '#f6f6f6',
         fontFamily: 'default',
-        margin: '2%'
+        margin: '2%',
+        marginLeft: '5%',
+        marginRight: '5%'
       }}
     >
       {/* everything above the profile list */}
-      <Grid container spacing={5} columnSpacing={{xs: 20, sm:80, md:5, lg:5}} columns={12} margin={8}>
-        <div class='headerContent'>
-          <Grid container spacing={6} columns={20} paddingBottom='10%'>
+      <Grid container spacing={3} columnSpacing={{xs: 20, sm:80, md:5, lg:5}} margin={10}>
+        <div className='headerContent'>
+          <Grid container spacing={3} columns={20} paddingBottom='10%'>
             {/* Left side of header */}
-            <Grid item xs={14} paddingRight='15%'>
+            <Grid item xs={12}>
               {/* Page Title */}
               <Typography variant="h4" justifyContent='center' sx={{fontWeight: 'bold', paddingBottom:'10%'}}>
                   Manage Profiles
               </Typography>
 
               {/* Search Bar */}
-              <Grid container spacing={2} columns={4}>
+              <Grid container spacing={3} columns={4}>
                 {/* Actual Search Bar */}
                 <Grid item xs={3}>
-                  <TextField fullWidth defaultValue="Search" InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} id="filled-basic" label="" variant="standard"/>
+                  <TextField fullWidth InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px', padding:'4px'}} id="filled-basic" label="" variant="standard"/>
                 </Grid>
                 {/* Search Button */}
                 <Grid item xs={1}>
                   <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">search</Button>
                 </Grid>
               </Grid>
+
+              {/* Applied filters */}
+              <Grid container spacing={2} item xs={12} paddingTop='2%' alignItems="center">
+                <Grid item xs={2}>
+                  applied filters:
+                </Grid>
+                <Grid item xs={10}>
+                  <TextField defaultValue="All" InputProps={{ readOnly: true }} sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px' }} id="filled-basic" label="" variant="standard" />
+                </Grid>
+              </Grid>
+
+
             </Grid>
+
+            <Grid item xs={1} />
             
             {/* Right side of header */}
             <Grid item xs={6}>
@@ -55,10 +73,22 @@ const BoxSx = () => {
               </Grid>
 
               {/* Select filters */}
+              {/* MUI Multiple values: https://mui.com/material-ui/react-autocomplete/#multiple-values */}
               <Grid container spacing={2} columns={3}>
                 <Grid item xs={2}>
-                  <TextField fullWidth defaultValue="Select filters" InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} id="filled-basic" label="" variant="standard"/>
+                  <Select
+                    fullWidth
+                    value="" // Set the initial value to an empty string
+                    displayEmpty // Display the selected value even when it's empty
+                    sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px', height: '38px'}}
+                  >
+                    <MenuItem value="" disabled>
+                      Select filters
+                    </MenuItem>
+                    {/* Add more MenuItem components with filter options here */}
+                  </Select>
                 </Grid>
+                {/* Filter button */}
                 <Grid item xs={1}>
                   <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">filter</Button>
                 </Grid>
@@ -72,10 +102,8 @@ const BoxSx = () => {
               {profileList({firstName: "N", lastName: "P", role: "volunteer", imageUrl: "image"})}
             </Grid>
           </div>
-
+          
         </div>
-        
-        
       </Grid>
   </Box>);
 }

--- a/app/components/manage-profiles.tsx
+++ b/app/components/manage-profiles.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Unstable_Grid2' ;
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
+import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import profileList from "./profileList"
 
@@ -33,9 +34,11 @@ const BoxSx = () => {
 
               {/* Search Bar */}
               <Grid container spacing={2} columns={4}>
+                {/* Actual Search Bar */}
                 <Grid item xs={3}>
                   <TextField fullWidth defaultValue="Search" InputProps={{readOnly: true }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} id="filled-basic" label="" variant="standard"/>
                 </Grid>
+                {/* Search Button */}
                 <Grid item xs={1}>
                   <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">search</Button>
                 </Grid>

--- a/app/components/manage-profiles.tsx
+++ b/app/components/manage-profiles.tsx
@@ -8,6 +8,8 @@ import Select from '@mui/material/Select';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import profileList from "./profileList"
+import Image from "next/image";
+import Add from "app/images/9.png";
 
 const BoxSx = () => {
   return (
@@ -66,14 +68,14 @@ const BoxSx = () => {
             {/* Right side of header */}
             <Grid item xs={6}>
               {/* Add new employee */}
-              <Grid container paddingBottom='16%'>
-                <Button fullWidth variant="outlined" sx={{ padding: '5%', borderRadius: '25px', textIndent: '10px', borderColor: "#57228F", backgroundColor: '#FFFFFF', color: "#000000", '&:hover': {borderColor:"#57228F"}, textTransform: 'none'}}>
-                    Add New Employee
+              <Grid container paddingBottom='18%'>
+                <Button fullWidth variant="outlined" sx={{ padding: '3%', borderRadius: '25px', borderColor: "#57228F", backgroundColor: '#FFFFFF', color: "#000000", '&:hover': {borderColor:"#57228F"}, textTransform: 'none', display: 'flex', alignItems: 'center' }}>
+                  <div style={{ flexGrow: 1 }}>Add New Employee</div>
+                  <Image src={Add} alt="Error" width={30} height={30} />
                 </Button>
               </Grid>
 
               {/* Select filters */}
-              {/* MUI Multiple values: https://mui.com/material-ui/react-autocomplete/#multiple-values */}
               <Grid container spacing={2} columns={3}>
                 <Grid item xs={2}>
                   <Select

--- a/app/components/manage-profiles.tsx
+++ b/app/components/manage-profiles.tsx
@@ -19,8 +19,11 @@ const BoxSx = () => {
       sx={{
         display: 'flex',
         minHeight: '90vh',
-        justifyContent: 'center',
-        alignItems: 'flex-start',
+        // justifyContent: 'center',
+        // alignItems: 'flex-start',
+        flexDirection: 'column', // Change flex direction to column
+        justifyContent: 'flex-start', // Align items at the start
+        alignItems: 'center', // Center items horizontally
         borderRadius: '5%',
         backgroundColor: '#f6f6f6',
         fontFamily: 'default',
@@ -101,9 +104,9 @@ const BoxSx = () => {
         </Stack>
 
         {/* Pagination */}
-        <div sx={{display:'flex', justifyContent:'center'}}>
-          <Pagination count={10} variant="outlined" color="secondary" /> 
-        </div>
+        <Stack spacing={2} alignItems="center">
+          <Pagination count={10} color="secondary" /> 
+        </Stack>
       </Stack>
   </Box>);
 }

--- a/app/components/profileList.tsx
+++ b/app/components/profileList.tsx
@@ -8,27 +8,9 @@ import { Transform } from '@mui/icons-material';
 import CreateIcon from '@mui/icons-material/Create';
 import IconButton from '@mui/material/IconButton';
 
-
-
-
 const profileList = ({firstName, lastName, role, imageUrl} : {firstName: string, lastName: string, role: string, imageUrl: string}) => {
   return (
-   
-    <Box
-    sx={{
-      display: 'flex',
-      bgcolor: 'silver',
-      boxShadow: 1,
-      borderRadius: 4,
-      height: '650px',
-      minWidth: 250,
-     
-      p:5,
-      justifyContent: 'flex-end',
-    }}>
-    
-    <Box
-     
+  <Box
     sx={{
       bgcolor: 'background.paper',
       boxShadow: 1,
@@ -64,13 +46,10 @@ const profileList = ({firstName, lastName, role, imageUrl} : {firstName: string,
             <CreateIcon />
           </IconButton>
 
-            </Stack>
-
-            
-        </Stack> </Box>
+            </Stack>  
+        </Stack> 
   </Box>
   )
 }
 
 export default profileList;
-

--- a/app/employer-manage-profiles/[[...employer-manage-profiles]]/page.tsx
+++ b/app/employer-manage-profiles/[[...employer-manage-profiles]]/page.tsx
@@ -1,5 +1,5 @@
-import profileList from "../../components/profileList"
+import manageProfiles from "../../components/manage-profiles"
 
 export default function Page() {
-  return profileList({firstName: "N", lastName: "P", role: "volunteer", imageUrl: "image"});
+  return manageProfiles();
 }


### PR DESCRIPTION
Developers: Jiyoon Choi

Dates: Nov 5 - Nov 12

Time spent: 3 hours

Summary: Created the "Manage profiles" page which will be viewable only by managers.

Clarification/note: I imported the profileList component instead of the placeholder box after playing around with the code

Testing:
<img width="1440" alt="Screen Shot 2023-11-11 at 11 54 35 PM" src="https://github.com/elizabethfoster02/casa-myrna/assets/46614509/320f52bb-e1aa-4c41-969f-b44f3bdbd80f">

Figma Design (for reference):
<img width="629" alt="Screen Shot 2023-11-12 at 12 09 33 AM" src="https://github.com/elizabethfoster02/casa-myrna/assets/46614509/abc42672-5597-4efd-a2b1-0dec288084be">

Reflection: 
This really got me to learn how to use Stacks and Grids! The colors/outlines/style stuff is still not exactly like the design, but the general shapes and components should all be there.